### PR TITLE
TRIVIAL: Upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "babel-eslint": "7.1.1",
-    "eslint": "3.11.1",
-    "eslint-config-airbnb": "13.0.0",
+    "eslint": "3.13.1",
+    "eslint-config-airbnb": "14.0.0",
     "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-mocha": "4.7.0",
-    "eslint-plugin-react": "6.7.1"
+    "eslint-plugin-jsx-a11y": "3.0.2",
+    "eslint-plugin-mocha": "4.8.0",
+    "eslint-plugin-react": "6.9.0"
   }
 }


### PR DESCRIPTION
Testing on AD resulted in 154 errors, all caused by [react/require-default-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md)