### PR TITLE
RELATED: RAIL-4670 Allow console.error and console.warn

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -37,7 +37,7 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": 2,
         "import/no-extraneous-dependencies": [2, { devDependencies: true }],
         "import/order": 2,
-        "no-console": 2,
+        "no-console": [2, { allow: ["warn", "error"] }],
 
         // Test
         "jest/no-disabled-tests": 2,


### PR DESCRIPTION
Without this exception, you have to add eslint suppressing annotations when there is a legitimate reason to warn or show error to the user.